### PR TITLE
Add Phase 2 code-artifact metadata: LICENSE, CITATION.cff, DATASHEET.…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,118 @@
+# Changelog
+
+All notable changes to this project are documented in this file. The format
+is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this
+project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] — 2026-04-18
+
+### Added
+
+- **`experiments/` reproducibility package** (13,663 lines across 9 modules).
+  Single entry point for reproducing every table and figure in the NeurIPS
+  2026 paper *Reward-Type Ablation Reveals Mechanism-Dependent Algorithm
+  Rankings in Mixed-Motive Multi-Agent Evaluation*.
+  - `config.py` — single source of truth for all defaults (seeds, reward
+    types, environments, algorithms, oracle references, safety settings).
+  - `algorithms.py` — 16 training algorithms (IPPO, IA2C, ISAC, LOLA,
+    SelfPlay_PPO, IndependentREINFORCE, FCP; MAPPO, MADDPG, MATD3, MASAC,
+    M3DDPG, QMIX, VDN, COMA, MeanFieldAC), 7 game-theoretic oracles,
+    2 heuristic baselines (Random, TitForTat), 101 constant-action policies.
+  - `campaign.py` — unified orchestrator with subcommands `baseline`,
+    `private`, `cooperative`. Safety defaults on (checkpoints, GPU memory
+    monitoring, thermal monitoring, dynamic backpressure).
+  - `sensitivity.py` — network capacity sensitivity analysis.
+  - `audit.py` — behavioral audit (static response surface + temporal
+    deviation). Subcommands `static`, `temporal`, `analyze`.
+  - `evaluate.py` — policy evaluation and cross-seed aggregation.
+    Subcommands `agent`, `aggregate`.
+  - `analyze.py` — paper table and figure generators. Nine subcommands
+    covering returns summary, oracle comparison, MASAC instability,
+    learning curves, plots, reward-type ablation, and more.
+  - `validate.py` — dataset integrity checks. Subcommands `training`,
+    `audit`, `schema`.
+  - `monitor.py` — local-friendly progress, health, and disk monitor.
+    Subcommands `watch`, `clean-checkpoints`, `disk-status`, `health-check`.
+- **`REPRODUCE.md`** — step-by-step instructions for reproducing paper
+  results from the released datasets.
+- **`.github/workflows/tests.yml`** — pytest matrix on Python 3.9/3.10/3.11/3.12
+  × ubuntu-latest.
+- **`.github/workflows/install.yml`** — install-verification matrix on
+  macos-latest / ubuntu-latest / windows-latest × Python 3.10/3.12,
+  exercising Gymnasium and PettingZoo Parallel APIs.
+- **Root `LICENSE`** (MIT) covering the whole repository.
+- **`CITATION.cff`** for the GitHub "Cite this repository" button.
+- **`DATASHEET.md`** following Gebru et al. for the released datasets.
+- **`CHANGELOG.md`** (this file).
+
+### Changed
+
+- Root `README.md` expanded from a minimal profile to a full project landing
+  page with quick-start, installation, reproducibility pointer, case study
+  summary, and technical report references.
+- `coopetition_gym/README.md` extended with a new oracles section documenting
+  all 7 game-theoretic oracles and their TR-tier applicability, plus a
+  NeurIPS paper callout block.
+- Case study validation scores corrected to match the authoritative
+  `TR_validation/` suite values (Apache 52/60 = 86.7%; Apple 48/55 = 87.3%;
+  Samsung-Sony and Renault-Nissan unchanged at 58/60 = 96.7% and
+  49/60 = 81.7% respectively).
+- Paper and checklist corrected from 128 → 126 algorithms, with the breakdown
+  disaggregated as "16 training algorithms, 2 heuristic baselines,
+  7 game-theoretic oracles, and 101 constant-action policies".
+- Total campaign cost updated from approximate placeholder to the authoritative
+  invoice total of $8,100 USD.
+- Package version bumped from `0.3.0` to `1.0.0`.
+
+### Fixed
+
+- **Namespace-package shadowing** — when running from the repository root,
+  Python resolved `coopetition_gym` to the outer folder (which has no
+  top-level `__init__.py`) as a namespace package, causing attribute errors
+  when attempting to call `coopetition_gym.make(...)`. Fixed consistently
+  across every consolidated module via a dedicated import helper that
+  prepends the inner-package parent and drops stale imports.
+- **Install verification workflow** — Windows GitHub Actions runners default
+  to PowerShell, which does not understand the bash heredoc syntax used in
+  the install verification steps. Added `defaults.run.shell: bash` and
+  `working-directory: coopetition_gym` to avoid both the heredoc issue and
+  the namespace shadow in CI.
+
+### Validated
+
+- **143 pytest tests pass** on Python 3.9, 3.10, 3.11, 3.12 (ubuntu-latest).
+- **6 install-verification jobs pass** on macOS, Ubuntu, and Windows
+  × Python 3.10, 3.12.
+- **Deterministic regression** (Constant_50 on TrustDilemma-v0 seed 99) on a
+  fresh clone of the public GitHub repository matches the released dataset
+  within 1.7 × 10⁻⁷ relative error.
+- **Training regression** — IA2C (via SB3) and IndependentREINFORCE (custom
+  PyTorch) both train to completion through the consolidated orchestrator.
+
+### Not Included in the Public Release (Archived)
+
+Campaign-specific infrastructure referenced specific cloud-instance
+identifiers and SSH credentials, and has been archived to
+`.claude/experiments/archive/` rather than published:
+
+- Per-instance launch shell scripts (`run_instance*.sh`)
+- Algorithm-specific patch scripts (`isac_metrics_*.sh`, `oracle_nash_rerun.sh`)
+- Instance deployment and tarball scripts (`setup_remote.sh`,
+  `create_results_tarball.sh`, `monitor_all_instances.sh`)
+- Cloud-orchestration monitoring (`background_monitor.py`'s SSH-polling
+  functions)
+- Dataset extraction helpers tied to specific tarball filenames
+  (`post_process_results.py`, `merge_dataset.py`)
+
+---
+
+## [0.3.0] — 2026 (pre-consolidation)
+
+Editable-install package release of `coopetition-gym` supporting Gymnasium and
+PettingZoo APIs. Internal release; used during the NeurIPS 2026 training
+campaign.
+
+## [0.2.0] — 2025
+
+Initial public release of the Coopetition-Gym environment suite with 10
+environments and supporting utilities.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,98 @@
+cff-version: 1.2.0
+message: "If you use this software or the accompanying datasets in your research, please cite the technical reports and, if applicable, the forthcoming NeurIPS 2026 paper."
+title: "Strategic Coopetition: Coopetition-Gym benchmark and reproducibility package"
+type: software
+authors:
+  - family-names: Pant
+    given-names: Vik
+    affiliation: "Faculty of Information, University of Toronto"
+    orcid: "https://orcid.org/0000-0002-9017-7466"
+  - family-names: Yu
+    given-names: Eric
+    affiliation: "Faculty of Information, University of Toronto"
+repository-code: "https://github.com/vikpant/strategic-coopetition"
+url: "https://github.com/vikpant/strategic-coopetition"
+keywords:
+  - multi-agent reinforcement learning
+  - mixed-motive games
+  - coopetition
+  - benchmark
+  - PettingZoo
+  - Gymnasium
+  - trust dynamics
+  - collective action
+  - reciprocity
+  - interdependence
+license: MIT
+version: "1.0.0"
+date-released: "2026-04-18"
+
+# Preferred citation: when the NeurIPS 2026 paper is accepted and published,
+# users should cite the paper. While under review, users may cite this
+# software release directly.
+preferred-citation:
+  type: article
+  title: "Reward-Type Ablation Reveals Mechanism-Dependent Algorithm Rankings in Mixed-Motive Multi-Agent Evaluation"
+  authors:
+    - family-names: Pant
+      given-names: Vik
+      affiliation: "Faculty of Information, University of Toronto"
+    - family-names: Yu
+      given-names: Eric
+      affiliation: "Faculty of Information, University of Toronto"
+  year: 2026
+  journal: "NeurIPS 2026 Evaluations and Datasets Track (under review)"
+  notes: "Update this entry to the proceedings citation after acceptance."
+
+references:
+  - type: article
+    title: "Computational Foundations for Strategic Coopetition: Formalizing Interdependence and Complementarity"
+    authors:
+      - family-names: Pant
+        given-names: Vik
+      - family-names: Yu
+        given-names: Eric
+    year: 2025
+    journal: "arXiv preprint"
+    identifiers:
+      - type: other
+        value: "arXiv:2510.18802"
+
+  - type: article
+    title: "Computational Foundations for Strategic Coopetition: Formalizing Trust and Reputation Dynamics"
+    authors:
+      - family-names: Pant
+        given-names: Vik
+      - family-names: Yu
+        given-names: Eric
+    year: 2025
+    journal: "arXiv preprint"
+    identifiers:
+      - type: other
+        value: "arXiv:2510.24909"
+
+  - type: article
+    title: "Computational Foundations for Strategic Coopetition: Formalizing Collective Action and Loyalty"
+    authors:
+      - family-names: Pant
+        given-names: Vik
+      - family-names: Yu
+        given-names: Eric
+    year: 2026
+    journal: "arXiv preprint"
+    identifiers:
+      - type: other
+        value: "arXiv:2601.16237"
+
+  - type: article
+    title: "Computational Foundations for Strategic Coopetition: Formalizing Sequential Interaction and Reciprocity"
+    authors:
+      - family-names: Pant
+        given-names: Vik
+      - family-names: Yu
+        given-names: Eric
+    year: 2026
+    journal: "arXiv preprint"
+    identifiers:
+      - type: other
+        value: "arXiv:2604.01240"

--- a/DATASHEET.md
+++ b/DATASHEET.md
@@ -1,0 +1,331 @@
+# Datasheet for the Coopetition-Gym Datasets
+
+Following the framework proposed by Gebru et al., *Datasheets for Datasets*,
+Communications of the ACM (2021). This datasheet covers the two datasets
+released alongside the NeurIPS 2026 paper *Reward-Type Ablation Reveals
+Mechanism-Dependent Algorithm Rankings in Mixed-Motive Multi-Agent Evaluation*.
+
+| Dataset | Purpose | Size | HuggingFace repo |
+|---|---|---|---|
+| **coopetition-gym-v1** | Training results | 25,708 JSON files | `vikpant/coopetition-gym-v1` |
+| **coopetition-gym-audit** | Behavioral audit | 1,116 JSON files | `vikpant/coopetition-gym-audit` |
+
+---
+
+## Motivation
+
+### For what purpose were the datasets created?
+
+To support the NeurIPS 2026 paper submission demonstrating that algorithm
+rankings in mixed-motive multi-agent reinforcement learning are mechanism-
+dependent — specifically, that the dominance of Centralized Training with
+Decentralized Execution (CTDE) over independent learning breaks down
+systematically when the reward function structure is varied.
+
+The datasets enable independent researchers to:
+
+* Reproduce the paper's tables and figures using the published analysis
+  pipeline (`experiments.analyze`).
+* Extend the empirical analysis to new algorithms or new reward configurations
+  without re-running the 3,400-GPU-hour campaign.
+* Audit the training dynamics and behavioral characteristics of each algorithm.
+* Verify the exploitation-gradient claims made in the societal impact
+  discussion (Appendix G).
+
+### Who created the datasets?
+
+Vik Pant and Eric Yu, Faculty of Information, University of Toronto.
+
+### Who funded their creation?
+
+Cloud compute costs (approximately $8,100 USD) were self-funded by the first
+author. No external funding was involved.
+
+---
+
+## Composition
+
+### What do the instances represent?
+
+**Training dataset (`coopetition-gym-v1`)**: each instance is one training
+experiment — the result of training one algorithm on one environment under
+one reward configuration with one random seed. Each instance is a single JSON
+file with the following top-level structure:
+
+| Field | Type | Description |
+|---|---|---|
+| `algorithm` | str | Algorithm name (e.g., `ISAC`, `COMA`) |
+| `environment` | str | Environment ID (e.g., `TrustDilemma-v0`) |
+| `training_seed` | int | Seed in {99, 100, 101, 102, 103, 104, 105} |
+| `status` | str | `success` or `failed` |
+| `training_time_seconds` | float | Wall-clock training time |
+| `evaluation_time_seconds` | float | Wall-clock evaluation time |
+| `metrics` | object | Aggregated per-episode and per-seed metrics |
+| `timestamp` | str | ISO 8601 completion timestamp |
+| `gpu_id` | int | GPU index used during training (−1 for CPU) |
+| `tr_mode` | str | TR tier label (`tr1`, `tr2`, `tr3`, `tr4`) |
+
+The nested `metrics` object contains:
+
+* `mean_return`, `std_return` — evaluation return statistics
+* `mean_cooperation_rate` — mean fraction of endowment contributed
+* `mean_final_trust` — mean final-step trust level
+* `training_returns`, `training_timesteps` — training-time return curve
+* `training_metrics` — gradient-level diagnostics (loss values by step)
+* `tr_metrics` — TR-tier-specific domain metrics
+
+**Behavioral audit dataset (`coopetition-gym-audit`)**: two subsets covering
+the static response-surface audit (1,056 JSON files) and the temporal
+deviation audit (60 JSON files). See paper Appendix F for the full schema and
+the file `experiments/validate.py` (run
+`python -m experiments.validate schema static_audit`) for the full field list.
+
+### How many instances are there in total?
+
+* Training dataset: **25,708** JSON files across 7 subfolders:
+  `baseline_integrated/` (16,835), `ablation_private/` (2,450),
+  `ablation_cooperative/` (2,450), `case_study/` (3,402),
+  `france_bonus_isac_integrated/` (21), `local_bonus/` (70),
+  `network_sensitivity/` (480).
+* Audit dataset: **1,116** JSON files (1,056 static + 60 temporal).
+
+### Does the dataset contain all possible instances or is it a sample?
+
+The training dataset is a *complete factorial* over the published experimental
+design: 16 training algorithms × 20 environments × 3 reward types × 7 seeds,
+minus MeanFieldAC's 24 exclusions on two-agent environments (the mean-field
+approximation is degenerate for N=2), plus supplementary case study and
+sensitivity experiments. The 62 NaN-return files arise from documented
+training instabilities in specific algorithm-environment-reward combinations
+and are retained for transparency; they are excluded from the paper's numerical
+analyses.
+
+The audit dataset is a complete factorial over 18 policies × 20 environments
+× 3 seeds, minus 24 MeanFieldAC dyadic exclusions = 1,056 static-audit files;
+plus 20 environments × 3 seeds = 60 temporal-audit files.
+
+### What data does each instance consist of?
+
+Raw scalar metrics, training curves, and diagnostic telemetry from simulation
+experiments. No images, audio, text, or user-generated content. No personally
+identifiable information of any kind.
+
+### Is any information missing from individual instances?
+
+For 62 training-dataset files, certain per-episode metrics are `NaN` due to
+documented training instability (21 MASAC baseline, 21 MADDPG/MATD3/M3DDPG
+cooperative, 20 MADDPG network-sensitivity). These are retained for full
+transparency of the campaign output; `experiments.validate training` reports
+the 62-count as an expected invariant.
+
+### Are relationships between individual instances made explicit?
+
+Yes. Instances are identified by the tuple
+`(algorithm, environment, seed, reward_type)`. The file-naming convention
+`{algorithm}_{environment}_{seed}.json` within the corresponding reward-type
+subfolder encodes all four dimensions.
+
+### Are there recommended data splits?
+
+The dataset is a factorial design, not a train/test split. Researchers
+typically aggregate across seeds for statistical summaries (see
+`experiments.evaluate aggregate`) or compare pairs of conditions
+(e.g., private vs. integrated reward).
+
+### Are there any errors, sources of noise, or redundancies?
+
+* **Seed variance**: training algorithms are stochastic; the same
+  (algorithm, environment, reward_type) triple with different seeds may
+  produce returns differing by up to 20% at convergence. This is not error;
+  it is the stochasticity the 7-seed design is meant to quantify.
+* **Documented NaN returns**: 62 files, as noted above.
+* **No redundancy**: each instance is a unique experiment.
+
+### Is the dataset self-contained, or does it link to external resources?
+
+Self-contained. Each JSON file encodes the full result of one experiment.
+The environment simulation code required to regenerate or extend the dataset
+lives in the companion GitHub repository
+(`https://github.com/vikpant/strategic-coopetition`).
+
+### Does the dataset contain data that might be considered confidential or sensitive?
+
+No. All data is synthetic simulation output from open-source environments.
+No human subjects, no proprietary information, no trade secrets. The case
+study calibrations (Samsung-Sony, Renault-Nissan, Apache, Apple) are based
+on publicly documented historical business decisions.
+
+### Does the dataset contain data that might be offensive, insulting, threatening, or otherwise cause anxiety?
+
+No.
+
+---
+
+## Collection Process
+
+### How was the data acquired?
+
+By running the experiments in `experiments/campaign.py` on cloud GPU
+infrastructure over approximately 3,400 GPU-hours distributed across 7 cloud
+instances during March–April 2026. Each experiment consisted of training one
+algorithm on one environment for 500,000 or 1,000,000 environment steps
+(depending on environment category), followed by evaluation of the trained
+policy on 100 episodes.
+
+### What mechanisms or procedures were used to collect the data?
+
+* Orchestration: `experiments/campaign.py` (unified orchestrator with
+  bin-packed GPU allocation and resume-aware dispatch).
+* Simulation: Coopetition-Gym (Gymnasium and PettingZoo environment suite).
+* Training: implementation details for each of 16 algorithms, 7 oracles,
+  2 heuristics, and 101 constant-action policies are in
+  `experiments/algorithms.py`.
+* Result persistence: one JSON file per experiment, written atomically on
+  training completion.
+
+### Over what timeframe was the data collected?
+
+Primary training campaign: February 13, 2026 – April 14, 2026.
+Behavioral audit: April 15, 2026.
+
+### Were any ethical review processes conducted?
+
+No human subjects were involved. No institutional review board approval
+was required or sought. The work is pure computational simulation of
+abstract coopetitive dynamics.
+
+---
+
+## Preprocessing
+
+### Was any preprocessing done?
+
+The released dataset is the *raw* orchestrator output. No post-hoc filtering
+or transformation was applied. The analysis pipeline (`experiments/analyze.py`)
+performs aggregation (e.g., mean ± std across seeds) at analysis time, not at
+collection time.
+
+### Is the software used to preprocess the data available?
+
+Yes. `experiments/analyze.py` contains the full analysis pipeline used to
+produce the paper's tables and figures from the raw JSON files.
+
+---
+
+## Uses
+
+### Has the dataset been used for any tasks already?
+
+The companion NeurIPS 2026 paper. No other uses at time of release.
+
+### Is there a repository that links to any or all papers or systems that use the dataset?
+
+The GitHub repository README lists the NeurIPS paper as the primary user.
+Future uses will be tracked as they become available.
+
+### What other tasks could the dataset be used for?
+
+* Developing algorithms specifically tuned for mixed-motive multi-agent
+  settings.
+* Meta-analysis across reward configurations and mechanism classes.
+* Uncertainty quantification and Bayesian modeling of MARL outcomes.
+* Failure-mode characterization (see the paper's MASAC instability analysis).
+* Educational material illustrating the reward-type ablation methodology.
+
+### Are there tasks for which the dataset should not be used?
+
+The dataset should **not** be used for:
+
+* Training policies for deployment in actual business settings without
+  extensive additional validation. The validated case studies (Samsung-Sony,
+  Renault-Nissan, Apache, Apple) model real-world partnerships at an abstract
+  level; transferring policies to operational decision-making requires
+  domain-specific validation beyond the scope of this work.
+* Claims about human cooperative behavior. The dataset reflects agent
+  behavior under synthetic reward structures; it does not reflect empirical
+  human behavior.
+
+### Are there any risks of harm?
+
+Limited, but noted in Appendix G of the paper:
+
+1. The integrated reward configuration permits exploitation when the private
+   gain exceeds the weighted partner loss. The behavioral audit empirically
+   bounds this vulnerability (see Appendix F), but deploying policies trained
+   under this configuration without further auditing is not recommended.
+2. Policies that appear cooperative at a static cooperation level may be
+   instrumentally motivated. The paper's methodology (reward-type ablation)
+   is designed to surface such cases; users of derived policies should
+   apply similar scrutiny.
+
+---
+
+## Distribution
+
+### Will the dataset be distributed to third parties?
+
+Yes, via HuggingFace Hub under CC-BY-4.0.
+
+### When will the dataset be released?
+
+Training dataset and audit dataset: on or before May 6, 2026, to coincide
+with NeurIPS 2026 Evaluations and Datasets Track submission.
+
+### Will the dataset be distributed under a copyright or IP license?
+
+CC-BY-4.0 (Creative Commons Attribution 4.0 International). Users may
+share and adapt the dataset for any purpose, including commercial, provided
+attribution is given to the original authors.
+
+### Have any third parties imposed IP-based or other restrictions on the data?
+
+No.
+
+### Do any export controls or regulatory restrictions apply?
+
+None known.
+
+---
+
+## Maintenance
+
+### Who will be supporting, hosting, and maintaining the dataset?
+
+Vik Pant. HuggingFace Hub provides hosting; GitHub Issues on the companion
+repository (`vikpant/strategic-coopetition`) provides the primary issue
+tracker.
+
+### How can the owner be contacted?
+
+Via GitHub Issues at `https://github.com/vikpant/strategic-coopetition/issues`
+or email vik.pant@utoronto.ca.
+
+### Is there an erratum?
+
+None at release. Any corrections will be recorded in the GitHub repository's
+CHANGELOG.md and on the HuggingFace dataset page.
+
+### Will the dataset be updated?
+
+The **v1** dataset released for NeurIPS 2026 is frozen as a reproducibility
+reference. Future extensions (e.g., biaxial action spaces, dynamic D_ij) will
+be released as separate versioned datasets (v2, v3, ...) with their own
+datasheets.
+
+### Will old versions continue to be supported?
+
+Yes. HuggingFace preserves version history; archived tags will remain
+accessible indefinitely.
+
+### If others want to extend, augment, or build on the dataset, is there a mechanism for them to do so?
+
+Yes. The reproducibility package in `experiments/` supports:
+
+* Running additional algorithms on the existing environments.
+* Running the existing algorithms on new environments.
+* Running reward ablations on any (algorithm, environment) pair.
+* Running behavioral audits on new (algorithm, environment) pairs.
+
+Contributors should submit pull requests to the GitHub repository. Extended
+datasets derived from the released v1 dataset should cite the original work
+and release under CC-BY-4.0 (per the terms of the original license).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,34 @@
+MIT License
+
+Copyright (c) 2025-2026 Vik Pant, Eric Yu - University of Toronto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+Notes:
+
+This license covers the code in this repository, including:
+
+  coopetition_gym/   the Python package (also covered by its own LICENSE file)
+  experiments/       the reproducibility package for the NeurIPS 2026 paper
+  TR_validation/     the validation suites reproducing the technical reports
+
+Datasets released to HuggingFace Hub under the companion paper are licensed
+separately under CC-BY-4.0. See the dataset pages on HuggingFace for details.

--- a/coopetition_gym/pyproject.toml
+++ b/coopetition_gym/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "coopetition-gym"
-version = "0.3.0"
+version = "1.0.0"
 description = "Multi-agent RL environments for strategic coopetition with trust dynamics, collective action, and PettingZoo support"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
…md, CHANGELOG.md, version 1.0.0

Completes Phase 2 (Code Artifact) of the NeurIPS 2026 pre-submission checklist by adding the metadata files expected by GitHub, the NeurIPS E&D track, and Croissant-adjacent reviewers.

- LICENSE: root MIT license with dataset-license note (CC-BY-4.0).
- CITATION.cff: GitHub "Cite this" button, NeurIPS paper preferred citation with arXiv references to the 4 technical reports.
- DATASHEET.md: Gebru et al. datasheet covering both released datasets (coopetition-gym-v1 training, coopetition-gym-audit behavioral).
- CHANGELOG.md: Keep-a-Changelog format with detailed v1.0.0 entry.
- pyproject.toml: version bump 0.3.0 to 1.0.0.

No code changes; documentation and metadata only.