### PR TITLE
Clarify TR-3 and TR-4 implementation architecture (docs only, v1.0.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,54 @@ All notable changes to this project are documented in this file. The format
 is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] — 2026-04-19
+
+### Documentation clarifications
+
+- **Clarified role of `core/collective_action.py`** — module docstring
+  rewritten to state that this module provides support utilities
+  (dataclasses, state-tracking containers) used by the TR-3
+  environments, and that the authoritative TR-3 paper formalism is
+  implemented in `envs/collective_action_envs.py`. No code changes.
+- **Clarified role of `core/reciprocity.py`** — module docstring
+  rewritten to state that this module provides support utilities used
+  by the TR-4 environments, and that the authoritative TR-4 paper
+  formalism is implemented in `envs/reciprocity_envs.py`. No code
+  changes.
+- **Added architectural pointer to `envs/collective_action_envs.py`** —
+  module docstring now explicitly identifies this file as the
+  authoritative TR-3 implementation and points to the `core/` helper
+  location.
+- **Added architectural pointer to `envs/reciprocity_envs.py`** —
+  module docstring now explicitly identifies this file as the
+  authoritative TR-4 implementation and points to the `core/` helper
+  location.
+
+### Provenance notes
+
+- The code state that produced the 25,708-file training dataset and
+  the 1,116-file behavioral audit dataset is preserved at the git tag
+  `v1.0.0-campaign` on `master`. Users who require byte-exact
+  reproduction of campaign-era package behavior should pin to that
+  tag.
+- All 143 pytest tests pass on v1.0.1 with identical behavior to
+  v1.0.0. No computational code, no class or function signatures, no
+  import paths, and no numerical outputs have changed.
+
+### Not changed
+
+- `experiments/` reproducibility package (unchanged)
+- Algorithm implementations (unchanged)
+- Dataset formats or contents (unchanged)
+- `coopetition_gym` public API surface (unchanged)
+- Class and function names in `core/collective_action.py` and
+  `core/reciprocity.py` (unchanged; these remain stable across v1.x).
+  Consolidation of these helper modules into `envs/` or renaming to
+  `core/*_support.py` is reserved for v2.0.0, where a SemVer-major
+  break is already planned.
+
+---
+
 ## [1.0.0] — 2026-04-18
 
 ### Added

--- a/coopetition_gym/coopetition_gym/core/collective_action.py
+++ b/coopetition_gym/coopetition_gym/core/collective_action.py
@@ -1,36 +1,53 @@
 """
 ================================================================================
-COOPETITION-GYM: Collective Action & Loyalty Module (TR-3)
+COOPETITION-GYM: TR-3 Support Utilities (Collective Action & Loyalty)
 ================================================================================
 
 Technical Report: TR-3 (arXiv:2601.16237)
 Title: Computational Foundations for Strategic Coopetition:
        Formalizing Collective Action and Loyalty
 
-This module implements TR-3 concepts. Currently provides skeleton
-interfaces for forward compatibility with full implementation planned for v0.2.x.
+Role in the package
+-------------------
+This module provides SUPPORT UTILITIES used by the TR-3 environments:
+dataclasses for free-rider parameters, state-tracking structures for
+loyalty scores and coalition membership, and helper functions used
+internally by the TR-3 environment classes.
 
-TR-3 Focus Areas:
------------------
-1. Collective Action Problems
-   - N-agent coordination challenges
-   - Critical mass thresholds for partnership success
-   - Free-rider detection and response
+It is NOT the authoritative implementation of the TR-3 paper formalism.
 
-2. Loyalty Dynamics
-   - Commitment persistence over time
-   - Loyalty rewards for sustained cooperation
-   - Defection penalties and exclusion mechanisms
+Authoritative TR-3 implementation
+---------------------------------
+The authoritative implementation of the TR-3 mathematical formalism ---
+team production Q(a) = ω(Σa_i)^β, base team payoff π_i^team = (1/n)Q(a) - c·a_i,
+loyalty modifier L_i = θ_i·[φ_B·π̄_{-i} + φ_C·c·a_i], and the
+free-riding equilibrium a* = (ωβ/(nc))^(1/(1-β)) --- lives in
+envs/collective_action_envs.py. See the TR3Parameters dataclass and
+accompanying helper functions (team_production, base_team_payoff,
+teammates_payoff, loyalty_modifier, loyalty_augmented_utility) there.
 
-3. Coalition Stability
-   - Conditions for partnership sustainability
-   - Entry/exit dynamics
-   - Minimum viable coalition size
+Exposed names (stable public API in v1.x)
+-----------------------------------------
+- CollectiveActionParameters: auxiliary params for free-rider and coalition logic
+- CollectiveActionState: state-tracking container (loyalty scores, coalition
+  membership, exclusion lists, coordination flags)
+- CollectiveActionModel: small wrapper providing helper methods
 
-Key Distinction:
+These names are stable across v1.x. A cleaner architectural consolidation
+(merging these support utilities into envs/collective_action_envs.py or
+renaming to core/collective_action_support.py) is planned for v2.0.0,
+where a SemVer-major break is acceptable.
+
+TR-3 focus areas
 ----------------
-TR-3 concerns INTERNAL partnership dynamics (coordination within coalition),
-NOT external market competition between firms.
+1. Collective action problems: N-agent coordination, critical mass,
+   free-rider detection.
+2. Loyalty dynamics: commitment persistence, loyalty rewards,
+   defection penalties, exclusion mechanisms.
+3. Coalition stability: entry/exit dynamics, minimum viable size.
+
+Key distinction: TR-3 concerns INTERNAL partnership dynamics
+(coordination within coalition), NOT external market competition.
 
 Authors: Vik Pant, Eric Yu
          Faculty of Information, University of Toronto

--- a/coopetition_gym/coopetition_gym/core/reciprocity.py
+++ b/coopetition_gym/coopetition_gym/core/reciprocity.py
@@ -1,32 +1,53 @@
 """
 ================================================================================
-COOPETITION-GYM: Sequential Interaction & Reciprocity Module (TR-4)
+COOPETITION-GYM: TR-4 Support Utilities (Sequential Interaction & Reciprocity)
 ================================================================================
 
-This module will implement TR-4 when available. Currently provides skeleton
-interfaces for forward compatibility.
+Technical Report: TR-4 (arXiv:2604.01240)
+Title: Computational Foundations for Strategic Coopetition:
+       Formalizing Sequential Interaction and Reciprocity
 
-TR-4 Focus Areas:
------------------
-1. Conditional Cooperation
-   - "I cooperate if you cooperated"
-   - Threshold-based reciprocity
-   - Gradual vs. binary responses
+Role in the package
+-------------------
+This module provides SUPPORT UTILITIES used by the TR-4 environments:
+parameter dataclasses for forgiveness and punishment logic,
+state-tracking containers for cooperation history and punishment
+counters, and helper functions used internally by the TR-4 environment
+classes.
 
-2. Sequential Reciprocity
-   - Turn-based reaction dynamics
-   - Observation before action
-   - Strategic timing of cooperation/defection
+It is NOT the authoritative implementation of the TR-4 paper formalism.
 
-3. Forgiveness & Punishment
-   - Recovery from defection episodes
-   - Punishment severity and duration
-   - Forgiveness conditions
+Authoritative TR-4 implementation
+---------------------------------
+The authoritative implementation of the TR-4 mathematical formalism ---
+cooperation signal s_ij = a_j - ā_j (Eq 19), memory-windowed baseline
+(Eq 20), bounded response φ(x) = tanh(κx) (Eq 21), reciprocity
+sensitivity ρ_ij = ρ_0·D_ij^η (Eq 23), trust-gated reciprocity modifier
+U_recip = λ_R Σ T_ij·(1 + ω·D_ij)·ρ_ij·φ(s_ij) (Eq 44), and the
+complete utility U_i = π_base + U_interdep + U_trust + U_recip (Eq 45)
+--- lives in envs/reciprocity_envs.py. See the TR4Parameters dataclass
+and accompanying helper functions (cooperation_signal, memory_average,
+bounded_response, reciprocity_sensitivity, trust_gated_reciprocity) there.
 
-4. History Dependence
-   - How past trajectories shape present choices
-   - Memory horizons
-   - Weighted recency effects
+Exposed names (stable public API in v1.x)
+-----------------------------------------
+- ReciprocityParameters: auxiliary params for forgiveness/punishment logic
+- ReciprocityState: state-tracking container (cooperation history,
+  punishment counters, forgiveness counters, grim-trigger flags)
+- ReciprocityModel: small wrapper providing helper methods
+
+These names are stable across v1.x. A cleaner architectural consolidation
+(merging these support utilities into envs/reciprocity_envs.py or renaming
+to core/reciprocity_support.py) is planned for v2.0.0.
+
+TR-4 focus areas
+----------------
+1. Conditional cooperation: threshold-based reciprocity, gradual vs.
+   binary responses.
+2. Sequential reciprocity: turn-based reaction, observation before action.
+3. Forgiveness and punishment: recovery dynamics, punishment severity,
+   forgiveness conditions.
+4. History dependence: memory horizons, weighted recency.
 
 Authors: Vik Pant, Eric Yu
          Faculty of Information, University of Toronto

--- a/coopetition_gym/coopetition_gym/envs/collective_action_envs.py
+++ b/coopetition_gym/coopetition_gym/envs/collective_action_envs.py
@@ -3,6 +3,13 @@
 COOPETITION-GYM: Collective Action Environments (TR-3 Category)
 ================================================================================
 
+AUTHORITATIVE TR-3 implementation. The full paper formalism
+(team production Q, base team payoff, loyalty modifier, free-riding
+equilibrium) is implemented in this file via the TR3Parameters
+dataclass and its helper functions. Auxiliary state-tracking
+utilities (CollectiveActionParameters, CollectiveActionState,
+CollectiveActionModel) live in core/collective_action.py.
+
 Technical Report: TR-3 (arXiv:2601.16237)
 Title: Computational Foundations for Strategic Coopetition:
        Formalizing Collective Action and Loyalty

--- a/coopetition_gym/coopetition_gym/envs/reciprocity_envs.py
+++ b/coopetition_gym/coopetition_gym/envs/reciprocity_envs.py
@@ -3,7 +3,15 @@
 COOPETITION-GYM: Reciprocity Environments (TR-4 Category)
 ================================================================================
 
-Technical Report: TR-4 (forthcoming)
+AUTHORITATIVE TR-4 implementation. The full paper formalism
+(cooperation signal, memory-windowed baseline, bounded response,
+reciprocity sensitivity, trust-gated reciprocity modifier, and
+complete utility) is implemented in this file via the TR4Parameters
+dataclass and its helper functions. Auxiliary state-tracking utilities
+(ReciprocityParameters, ReciprocityState, ReciprocityModel) live in
+core/reciprocity.py.
+
+Technical Report: TR-4 (arXiv:2604.01240)
 Title: Computational Foundations for Strategic Coopetition:
        Formalizing Sequential Interaction and Reciprocity
 

--- a/coopetition_gym/pyproject.toml
+++ b/coopetition_gym/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "coopetition-gym"
-version = "1.0.0"
+version = "1.0.1"
 description = "Multi-agent RL environments for strategic coopetition with trust dynamics, collective action, and PettingZoo support"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
Documentation-only clarifications for coopetition-gym 1.0.1:
- Rewrite module docstrings for core/collective_action.py and core/reciprocity.py to identify them as support utilities.
- Add pointer comments to envs/collective_action_envs.py and envs/reciprocity_envs.py identifying them as authoritative.
- Bump version 1.0.0 -> 1.0.1.
- Document changes in CHANGELOG.md.

No computational code changed. All 143 tests pass. Campaign-era state preserved at git tag v1.0.0-campaign.